### PR TITLE
Proposing Update to gsettings-desktop-directories-prime

### DIFF
--- a/gsettings-desktop-directories-prime
+++ b/gsettings-desktop-directories-prime
@@ -20,4 +20,8 @@ gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folder
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/AudioVideo/ categories "['AudioVideo']"
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/AudioVideo/ translate true
 
+gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/System/ name 'System.directory'
+gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/System/ categories "['System']"
+gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/System/ translate true
+
 touch $HOME/.config/kramden-gsettings-prime-done


### PR DESCRIPTION
Did a little research on gnome app folders and the default app categories. Based on what I read, my suggestion: Adding the System category to pull in htop, terminal, and a few others, see https://specifications.freedesktop.org/menu-spec/latest/apa.html Also checked the app menulibre to confirm which apps would go in this folder. Still will leave a few odd apps that could confuse users in the top of the App Overview but it seems that's inevitable.